### PR TITLE
Wrap strings intl.formatMessage for translation

### DIFF
--- a/components/Dialog/Dialog.tsx
+++ b/components/Dialog/Dialog.tsx
@@ -3,6 +3,7 @@ import { XIcon } from "@heroicons/react/outline";
 
 import Overlay from "./Overlay";
 import Content from "./Content";
+import { useIntl } from "react-intl";
 
 export type Color = "ts-primary";
 
@@ -37,6 +38,8 @@ const Dialog: React.FC<DialogProps> = ({
   closeButton,
   children,
 }) => {
+  const intl = useIntl();
+
   return (
     <Overlay
       isOpen={isOpen}
@@ -76,7 +79,9 @@ const Dialog: React.FC<DialogProps> = ({
                     "data-h2-font-color": "b(white)",
                   })}
             >
-              <span data-h2-visibility="b(invisible)">Close dialog</span>
+              <span data-h2-visibility="b(invisible)">
+                {intl.formatMessage({ defaultMessage: "Close dialog" })}
+              </span>
               <XIcon className="dialog-close__icon" />
             </button>
           )}

--- a/components/Home.tsx
+++ b/components/Home.tsx
@@ -229,9 +229,10 @@ const Home: React.FunctionComponent = () => {
                   </li>
                 </ul>
                 <p>
-                  Your Passport specifically relates to workplace situations.
-                  Please do not include any information about medical conditions
-                  or treatments.
+                  {intl.formatMessage({
+                    defaultMessage:
+                      "Your Passport specifically relates to workplace situations. Please do not include any information about medical conditions or treatments.",
+                  })}
                 </p>
               </div>
             </div>

--- a/components/ShareForm.tsx
+++ b/components/ShareForm.tsx
@@ -91,17 +91,8 @@ const ShareForm: React.FunctionComponent<ShareFormProps> = ({
               data-h2-justify-content="b(space-between)"
               data-h2-align-items="b(center)"
             >
-              <Link
-                href={`/${pathname.split("/")[1]}/share`}
-                key={intl.formatMessage({
-                  defaultMessage: "cancel",
-                })}
-              >
-                <a
-                  title={intl.formatMessage({
-                    defaultMessage: "cancel",
-                  })}
-                >
+              <Link href={`/${pathname.split("/")[1]}/share`} key="cancel">
+                <a>
                   {intl.formatMessage({
                     defaultMessage: "cancel",
                   })}

--- a/components/inputPartials/Fieldset/Fieldset.tsx
+++ b/components/inputPartials/Fieldset/Fieldset.tsx
@@ -1,5 +1,7 @@
 import { QuestionMarkCircleIcon, XCircleIcon } from "@heroicons/react/solid";
 import React, { useState } from "react";
+import { useIntl } from "react-intl";
+import commonMessages from "../../../messages/commonMessages";
 import InputContext from "../InputContext/InputContext";
 import InputError from "../InputError/InputError";
 
@@ -31,6 +33,7 @@ export const Fieldset: React.FC<FieldsetProps> = ({
   children,
 }) => {
   const [contextIsActive, setContextIsActive] = useState(false);
+  const intl = useIntl();
   return (
     <fieldset
       name={name}
@@ -59,7 +62,9 @@ export const Fieldset: React.FC<FieldsetProps> = ({
                   ? { "data-h2-font-color": "b(red)" }
                   : { "data-h2-font-color": "b(darkgray" })}
               >
-                {required ? "Required" : "Optional"}
+                {required
+                  ? intl.formatMessage(commonMessages.required)
+                  : intl.formatMessage(commonMessages.optional)}
               </span>
             )
           }

--- a/components/inputPartials/InputLabel/InputLabel.tsx
+++ b/components/inputPartials/InputLabel/InputLabel.tsx
@@ -60,7 +60,7 @@ export const InputLabel: React.FC<InputLabelProps> = ({
             type="button"
             className="input-label-context-button"
             data-h2-margin="b(left, xxs)"
-            title="Toggle Context"
+            title={intl.formatMessage({ defaultMessage: "Toggle Context" })}
             onClick={clickHandler}
           >
             {contextIsActive ? (

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -36,7 +36,12 @@ const AccountManagement: React.FunctionComponent = () => {
       data-h2-width="b(100) l(75)"
       data-h2-padding="b(all, none)"
       crumbs={[
-        { title: "Manage your account" },
+        {
+          title: intl.formatMessage({
+            defaultMessage: "Manage your account",
+            description: "Breadcrumb title.",
+          }),
+        },
       ]}
     >
       <Page>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,16 @@
 import * as React from "react";
+import { useIntl } from "react-intl";
 import Home from "../components/Home";
 import Layout from "../components/Layout";
 
 const HomePage: React.FunctionComponent = () => {
+  const intl = useIntl();
+
   return (
     <Layout
-      title="Homepage - GC Workplace Accessibility Passport"
+      title={intl.formatMessage({
+        defaultMessage: "Homepage - GC Workplace Accessibility Passport",
+      })}
       data-h2-padding="b(all, none)"
       crumbs={[]}
     >

--- a/pages/manager/manager-dashboard.tsx
+++ b/pages/manager/manager-dashboard.tsx
@@ -18,7 +18,14 @@ const ManagerDashboard: React.FunctionComponent = () => {
         defaultMessage:
           "Manager dashboard - GC Workplace Accessibility Passport",
       })}
-      crumbs={[{ title: "My Dashboard" }]}
+      crumbs={[
+        {
+          title: intl.formatMessage({
+            defaultMessage: "My Dashboard",
+            description: "Breadcrumb title.",
+          }),
+        },
+      ]}
     >
       <Page>
         <LeftSection>
@@ -35,9 +42,7 @@ const ManagerDashboard: React.FunctionComponent = () => {
               })}
             </h2>
             <PassportCard
-              title={intl.formatMessage({
-                defaultMessage: "Frank Turot",
-              })}
+              title="Frank Turot"
               link={{
                 title: intl.formatMessage({
                   defaultMessage: "View passport",
@@ -46,9 +51,7 @@ const ManagerDashboard: React.FunctionComponent = () => {
               }}
             />
             <PassportCard
-              title={intl.formatMessage({
-                defaultMessage: "Shannon Ghiles",
-              })}
+              title="Shannon Ghiles"
               link={{
                 title: intl.formatMessage({
                   defaultMessage: "View passport",
@@ -57,9 +60,7 @@ const ManagerDashboard: React.FunctionComponent = () => {
               }}
             />
             <PassportCard
-              title={intl.formatMessage({
-                defaultMessage: "Margaret Turing",
-              })}
+              title="Margaret Turing"
               link={{
                 title: intl.formatMessage({
                   defaultMessage: "View passport",

--- a/pages/manager/view-employee-barrier.tsx
+++ b/pages/manager/view-employee-barrier.tsx
@@ -18,10 +18,22 @@ const ReviewBarrier: React.FunctionComponent = () => {
           "Frank's Barrier: Noise in the workplace - GC Workplace Accessibility Passport",
       })}
       crumbs={[
-        { title: "My Dashboard", href: "/manager/manager-dashboard" },
-        { title: "Frank Turot", href: "/manager/view-employee-passport" },
         {
-          title: "Noise in the workplace",
+          title: intl.formatMessage({
+            defaultMessage: "My Dashboard",
+            description: "Breadcrumb title.",
+          }),
+          href: "/manager/manager-dashboard",
+        },
+        {
+          title: "Frank Turot",
+          href: "/manager/view-employee-passport",
+        },
+        {
+          title: intl.formatMessage({
+            defaultMessage: "Noise in the workplace",
+            description: "Breadcrumb title.",
+          }),
         },
       ]}
     >
@@ -70,9 +82,7 @@ const ReviewBarrier: React.FunctionComponent = () => {
               title={intl.formatMessage({
                 defaultMessage: "Noise cancelling headphones",
               })}
-              documentName={intl.formatMessage({
-                defaultMessage: "my_hearing_assessment.pdf(3MB)",
-              })}
+              documentName="my_hearing_assessment.pdf(3MB)"
               actionLinks={[
                 {
                   title: intl.formatMessage({ defaultMessage: "View" }),
@@ -94,9 +104,7 @@ const ReviewBarrier: React.FunctionComponent = () => {
               title={intl.formatMessage({
                 defaultMessage: "Access to quiet space",
               })}
-              documentName={intl.formatMessage({
-                defaultMessage: "location_assessment.pdf(3MB)",
-              })}
+              documentName="location_assessment.pdf(3MB)"
               actionLinks={[
                 {
                   title: intl.formatMessage({ defaultMessage: "View" }),
@@ -119,9 +127,7 @@ const ReviewBarrier: React.FunctionComponent = () => {
                 defaultMessage:
                   "Organizer / task planning tool/software application",
               })}
-              documentName={intl.formatMessage({
-                defaultMessage: "software_assessment.pdf(3MB)",
-              })}
+              documentName="software_assessment.pdf(3MB)"
               actionLinks={[
                 {
                   title: intl.formatMessage({ defaultMessage: "View" }),
@@ -182,11 +188,31 @@ const ReviewBarrier: React.FunctionComponent = () => {
               data-h2-margin="b(bottom-left, m)"
               style={{ listStyleType: "disc" }}
             >
-              <li>Example Resource #1</li>
-              <li>Example Resource #2</li>
-              <li>Example Resource #3</li>
-              <li>Example Resource #4</li>
-              <li>Example Resource #5</li>
+              <li>
+                {intl.formatMessage({
+                  defaultMessage: "Example Resource #1",
+                })}
+              </li>
+              <li>
+                {intl.formatMessage({
+                  defaultMessage: "Example Resource #2",
+                })}
+              </li>
+              <li>
+                {intl.formatMessage({
+                  defaultMessage: "Example Resource #3",
+                })}
+              </li>
+              <li>
+                {intl.formatMessage({
+                  defaultMessage: "Example Resource #4",
+                })}
+              </li>
+              <li>
+                {intl.formatMessage({
+                  defaultMessage: "Example Resource #5",
+                })}
+              </li>
             </ul>
           </div>
 

--- a/pages/manager/view-employee-passport.tsx
+++ b/pages/manager/view-employee-passport.tsx
@@ -18,8 +18,19 @@ const ViewEmployeePassport: React.FunctionComponent = () => {
           "Frank Turot's passport - GC Workplace Accessibility Passport",
       })}
       crumbs={[
-        { title: "My Dashboard", href: "/manager/manager-dashboard" },
-        { title: "Frank Turot" },
+        {
+          title: intl.formatMessage({
+            defaultMessage: "My Dashboard",
+            description: "Breadcrumb title.",
+          }),
+          href: "/manager/manager-dashboard",
+        },
+        {
+          title: intl.formatMessage({
+            defaultMessage: "Frank Turot",
+            description: "Breadcrumb title.",
+          }),
+        },
       ]}
     >
       <Page>
@@ -106,21 +117,13 @@ const ViewEmployeePassport: React.FunctionComponent = () => {
                 defaultMessage: "Phone",
               })}
             </p>
-            <p data-h2-margin="b(top, none)">
-              {intl.formatMessage({
-                defaultMessage: "(555)555-5555",
-              })}
-            </p>
+            <p data-h2-margin="b(top, none)">(555)555-5555</p>
             <p data-h2-font-weight="b(700)" data-h2-margin="b(bottom, none)">
               {intl.formatMessage({
                 defaultMessage: "Email",
               })}
             </p>
-            <p data-h2-margin="b(all, none)">
-              {intl.formatMessage({
-                defaultMessage: "frank.turot@example.gov.ca",
-              })}
-            </p>
+            <p data-h2-margin="b(all, none)">frank.turot@example.gov.ca</p>
           </div>
           <div>
             <h2 data-h2-font-size="b(h4)" data-h2-margin="b(bottom, none)">
@@ -143,16 +146,8 @@ const ViewEmployeePassport: React.FunctionComponent = () => {
                 defaultMessage: "Emergency Contact",
               })}
             </p>
-            <p data-h2-margin="b(top-bottom, none)">
-              {intl.formatMessage({
-                defaultMessage: "Gal Turot",
-              })}
-            </p>
-            <p data-h2-margin="b(top, none)">
-              {intl.formatMessage({
-                defaultMessage: "(555)555-5555",
-              })}
-            </p>
+            <p data-h2-margin="b(top-bottom, none)">Gal Turot</p>
+            <p data-h2-margin="b(top, none)">(555)555-5555</p>
             <div>
               <p data-h2-margin="b(bottom, none)" data-h2-font-weight="b(700)">
                 {intl.formatMessage({
@@ -164,11 +159,7 @@ const ViewEmployeePassport: React.FunctionComponent = () => {
                   <PaperClipIcon style={{ width: "1.2rem" }}> </PaperClipIcon>
                 </span>
                 <Link href="#">
-                  <a>
-                    {intl.formatMessage({
-                      defaultMessage: "my_evacuation_plan.pdf(3MB)",
-                    })}
-                  </a>
+                  <a>my_evacuation_plan.pdf(3MB)</a>
                 </Link>
               </div>
               <div data-h2-margin="b(bottom, m)" data-h2-display="b(flex)">
@@ -176,11 +167,7 @@ const ViewEmployeePassport: React.FunctionComponent = () => {
                   <PaperClipIcon style={{ width: "1.2rem" }}> </PaperClipIcon>
                 </span>
                 <Link href="#">
-                  <a>
-                    {intl.formatMessage({
-                      defaultMessage: "my_paramedical_needs.pdf(3MB)",
-                    })}
-                  </a>
+                  <a>my_paramedical_needs.pdf(3MB)</a>
                 </Link>
               </div>
             </div>

--- a/pages/manager/view-employee-solution.tsx
+++ b/pages/manager/view-employee-solution.tsx
@@ -31,14 +31,29 @@ const ViewSolution: React.FunctionComponent = () => {
           "Frank’s Solution: Noise-cancelling headphones - GC Workplace Accessibility Passport",
       })}
       crumbs={[
-        { title: "My Dashboard", href: "/manager/manager-dashboard" },
-        { title: "Frank Turot", href: "/manager/view-employee-passport" },
         {
-          title: "Noise in the workplace",
+          title: intl.formatMessage({
+            defaultMessage: "My Dashboard",
+            description: "Breadcrumb title.",
+          }),
+          href: "/manager/manager-dashboard",
+        },
+        {
+          title: "Frank Turot",
+          href: "/manager/view-employee-passport",
+        },
+        {
+          title: intl.formatMessage({
+            defaultMessage: "Noise in the workplace",
+            description: "Breadcrumb title.",
+          }),
           href: "/manager/view-employee-barrier",
         },
         {
-          title: "Noise cancelling headphones",
+          title: intl.formatMessage({
+            defaultMessage: "Noise cancelling headphones",
+            description: "Breadcrumb title.",
+          }),
         },
       ]}
     >
@@ -173,9 +188,7 @@ const ViewSolution: React.FunctionComponent = () => {
                 <LinkIcon style={{ width: "1rem" }} />
               </span>
               <a href="#" data-h2-display="b(inline-block)">
-                {intl.formatMessage({
-                  defaultMessage: "my_ergonomic_assessment.pdf(3MB)",
-                })}
+                my_ergonomic_assessment.pdf(3MB)
               </a>
             </div>
           </div>

--- a/pages/passport/barriers/identify-a-barrier.tsx
+++ b/pages/passport/barriers/identify-a-barrier.tsx
@@ -87,8 +87,19 @@ const IdentifyABarrier: React.FunctionComponent = () => {
           "Identify a barrier - GC Workplace Accessibility Passport",
       })}
       crumbs={[
-        { title: "My passport", href: "/passport" },
-        { title: "Identify a barrier" },
+        {
+          title: intl.formatMessage({
+            defaultMessage: "My passport",
+            description: "Breadcrumb title.",
+          }),
+          href: "/passport",
+        },
+        {
+          title: intl.formatMessage({
+            defaultMessage: "Identify a barrier",
+            description: "Breadcrumb title.",
+          }),
+        },
       ]}
       formLayout
     >

--- a/pages/passport/barriers/review-barrier.tsx
+++ b/pages/passport/barriers/review-barrier.tsx
@@ -20,8 +20,19 @@ const ReviewBarrier: React.FunctionComponent = () => {
           "Review or edit your barrier: Noise in the workplace - GC Workplace Accessibility Passport",
       })}
       crumbs={[
-        { title: "My passport", href: "/passport" },
-        { title: "Noise in the workplace" },
+        {
+          title: intl.formatMessage({
+            defaultMessage: "My passport",
+            description: "Breadcrumb title.",
+          }),
+          href: "/passport",
+        },
+        {
+          title: intl.formatMessage({
+            defaultMessage: "Noise in the workplace",
+            description: "Breadcrumb title.",
+          }),
+        },
       ]}
     >
       <Page>
@@ -67,9 +78,7 @@ const ReviewBarrier: React.FunctionComponent = () => {
               title={intl.formatMessage({
                 defaultMessage: "Noise cancelling headphones",
               })}
-              documentName={intl.formatMessage({
-                defaultMessage: "my_hearing_assessment.pdf(3MB)",
-              })}
+              documentName="my_hearing_assessment.pdf(3MB)"
               actionLinks={[
                 {
                   title: intl.formatMessage({ defaultMessage: "View" }),
@@ -103,9 +112,7 @@ const ReviewBarrier: React.FunctionComponent = () => {
               title={intl.formatMessage({
                 defaultMessage: "Access to quiet space",
               })}
-              documentName={intl.formatMessage({
-                defaultMessage: "location_assessment.pdf(3MB)",
-              })}
+              documentName="location_assessment.pdf(3MB)"
               actionLinks={[
                 {
                   title: intl.formatMessage({ defaultMessage: "View" }),
@@ -140,9 +147,7 @@ const ReviewBarrier: React.FunctionComponent = () => {
                 defaultMessage:
                   "Organizer / task planning tool/software application",
               })}
-              documentName={intl.formatMessage({
-                defaultMessage: "software_assessment.pdf(3MB)",
-              })}
+              documentName="software_assessment.pdf(3MB)"
               actionLinks={[
                 {
                   title: intl.formatMessage({ defaultMessage: "View" }),
@@ -268,11 +273,7 @@ const ReviewBarrier: React.FunctionComponent = () => {
                 data-h2-justify-content="b(space-between)"
                 data-h2-align-items="b(center)"
               >
-                <p data-h2-margin="b(all, none)">
-                  {intl.formatMessage({
-                    defaultMessage: "Jennifer Rotterdam",
-                  })}
-                </p>
+                <p data-h2-margin="b(all, none)">Jennifer Rotterdam</p>
                 <Link href="#">
                   <a>
                     {intl.formatMessage({
@@ -295,11 +296,7 @@ const ReviewBarrier: React.FunctionComponent = () => {
               data-h2-justify-content="b(space-between)"
               data-h2-align-items="b(center)"
             >
-              <p data-h2-margin="b(all, none)">
-                {intl.formatMessage({
-                  defaultMessage: "Barnabus Sui",
-                })}
-              </p>
+              <p data-h2-margin="b(all, none)">Barnabus Sui</p>
               <Link href="#">
                 <a>
                   {intl.formatMessage({

--- a/pages/passport/barriers/solutions/identify-a-solution-2.tsx
+++ b/pages/passport/barriers/solutions/identify-a-solution-2.tsx
@@ -80,13 +80,25 @@ const IdentifyASolution2: React.FunctionComponent = () => {
       })}
       formLayout
       crumbs={[
-        { title: "My passport", href: "/passport" },
         {
-          title: "Identify a barrier",
+          title: intl.formatMessage({
+            defaultMessage: "My passport",
+            description: "Breadcrumb title.",
+          }),
+          href: "/passport",
+        },
+        {
+          title: intl.formatMessage({
+            defaultMessage: "Identify a barrier",
+            description: "Breadcrumb title.",
+          }),
           href: "/passport/barriers/identify-a-barrier",
         },
         {
-          title: "Propose Solutions",
+          title: intl.formatMessage({
+            defaultMessage: "Propose Solutions",
+            description: "Breadcrumb title.",
+          }),
         },
       ]}
     >

--- a/pages/passport/barriers/solutions/identify-a-solution.tsx
+++ b/pages/passport/barriers/solutions/identify-a-solution.tsx
@@ -131,13 +131,25 @@ const IdentifyASolution: React.FunctionComponent = () => {
           "Identify a solution for Noise in the Workplace - GC Workplace Accessibility Passport",
       })}
       crumbs={[
-        { title: "My passport", href: "/passport" },
         {
-          title: "Identify a barrier",
+          title: intl.formatMessage({
+            defaultMessage: "My passport",
+            description: "Breadcrumb title.",
+          }),
+          href: "/passport",
+        },
+        {
+          title: intl.formatMessage({
+            defaultMessage: "Identify a barrier",
+            description: "Breadcrumb title.",
+          }),
           href: "/passport/barriers/identify-a-barrier",
         },
         {
-          title: "Propose Solutions",
+          title: intl.formatMessage({
+            defaultMessage: "Propose Solutions",
+            description: "Breadcrumb title.",
+          }),
         },
       ]}
       formLayout

--- a/pages/passport/barriers/solutions/review-solution.tsx
+++ b/pages/passport/barriers/solutions/review-solution.tsx
@@ -33,13 +33,25 @@ const ViewSolution: React.FunctionComponent = () => {
           "View/Action your solution: Noise-cancelling headphones - GC Workplace Accessibility Passport",
       })}
       crumbs={[
-        { title: "My passport", href: "/passport" },
         {
-          title: "Noise in the workplace",
+          title: intl.formatMessage({
+            defaultMessage: "My passport",
+            description: "Breadcrumb title.",
+          }),
+          href: "/passport",
+        },
+        {
+          title: intl.formatMessage({
+            defaultMessage: "Noise in the workplace",
+            description: "Breadcrumb title.",
+          }),
           href: "/passport/barriers/review-barrier",
         },
         {
-          title: "Noise-cancelling headphones",
+          title: intl.formatMessage({
+            defaultMessage: "Noise-cancelling headphones",
+            description: "Breadcrumb title.",
+          }),
         },
       ]}
     >
@@ -226,9 +238,7 @@ const ViewSolution: React.FunctionComponent = () => {
                 <PaperClipIcon style={{ width: "1.25rem" }} />
               </span>
               <a href="#" data-h2-display="b(inline-block)">
-                {intl.formatMessage({
-                  defaultMessage: "my_ergonomic_assessment.pdf(3MB)",
-                })}
+                my_ergonomic_assessment.pdf(3MB)
               </a>
             </div>
           </div>

--- a/pages/passport/index.tsx
+++ b/pages/passport/index.tsx
@@ -17,7 +17,14 @@ const Passport: React.FunctionComponent = () => {
       headTitle={intl.formatMessage({
         defaultMessage: "My Passport - GC Workplace Accessibility Passport",
       })}
-      crumbs={[{ title: "My passport" }]}
+      crumbs={[
+        {
+          title: intl.formatMessage({
+            defaultMessage: "My passport",
+            description: "Breadcrumb title.",
+          }),
+        },
+      ]}
     >
       <Page>
         <LeftSection>
@@ -209,11 +216,7 @@ const Passport: React.FunctionComponent = () => {
                       </PaperClipIcon>
                     </span>
                     <Link href="#">
-                      <a>
-                        {intl.formatMessage({
-                          defaultMessage: "my_evacuation_plan.pdf(3MB)",
-                        })}
-                      </a>
+                      <a>my_evacuation_plan.pdf(3MB)</a>
                     </Link>
                   </div>
                   <div data-h2-margin="b(bottom, m)" data-h2-display="b(flex)">
@@ -226,11 +229,7 @@ const Passport: React.FunctionComponent = () => {
                       </PaperClipIcon>
                     </span>
                     <Link href="#">
-                      <a>
-                        {intl.formatMessage({
-                          defaultMessage: "my_paramedical_needs.pdf(3MB)",
-                        })}
-                      </a>
+                      <a>my_paramedical_needs.pdf(3MB)</a>
                     </Link>
                   </div>
                 </div>

--- a/pages/passport/manage-permissions.tsx
+++ b/pages/passport/manage-permissions.tsx
@@ -59,9 +59,7 @@ const ManagePermissions: React.FunctionComponent = () => {
             </h3>
             <div data-h2-margin="b(bottom, l)">
               <PermissionsCard
-                title={intl.formatMessage({
-                  defaultMessage: "Sui Kiyoko",
-                })}
+                title="Sui Kiyoko"
                 actionLinks={[
                   intl.formatMessage({
                     defaultMessage: "Remove all access",
@@ -82,9 +80,7 @@ const ManagePermissions: React.FunctionComponent = () => {
               })}
             </h3>
             <PermissionsCard
-              title={intl.formatMessage({
-                defaultMessage: "Priyanka Luka",
-              })}
+              title="Priyanka Luka"
               actionLinks={[
                 intl.formatMessage({
                   defaultMessage: "Remove all access",

--- a/pages/passport/manage-permissions.tsx
+++ b/pages/passport/manage-permissions.tsx
@@ -19,9 +19,18 @@ const ManagePermissions: React.FunctionComponent = () => {
           "Manage permissions - GC Workplace Accessibility Passport",
       })}
       crumbs={[
-        { title: "My passport", href: "/passport" },
         {
-          title: "Manage Permissions",
+          title: intl.formatMessage({
+            defaultMessage: "My passport",
+            description: "Breadcrumb title.",
+          }),
+          href: "/passport",
+        },
+        {
+          title: intl.formatMessage({
+            defaultMessage: "Manage Permissions",
+            description: "Breadcrumb title.",
+          }),
         },
       ]}
     >

--- a/pages/passport/manager-info.tsx
+++ b/pages/passport/manager-info.tsx
@@ -35,8 +35,19 @@ const ManagerInfo: React.FunctionComponent = () => {
       center={true}
       formLayout
       crumbs={[
-        { title: "My passport", href: "/passport" },
-        { title: "Manager Info" },
+        {
+          title: intl.formatMessage({
+            defaultMessage: "My passport",
+            description: "Breadcrumb title.",
+          }),
+          href: "/passport",
+        },
+        {
+          title: intl.formatMessage({
+            defaultMessage: "Manager Info",
+            description: "Breadcrumb title.",
+          }),
+        },
       ]}
     >
       <FormProvider {...methods}>

--- a/pages/passport/share-my-passport.tsx
+++ b/pages/passport/share-my-passport.tsx
@@ -63,8 +63,19 @@ const ShareMyPassport: React.FunctionComponent = () => {
           "Share my passport information - GC Workplace Accessibility Passport",
       })}
       crumbs={[
-        { title: "My passport", href: "/passport" },
-        { title: "Share my passport" },
+        {
+          title: intl.formatMessage({
+            defaultMessage: "My passport",
+            description: "Breadcrumb title.",
+          }),
+          href: "/passport",
+        },
+        {
+          title: intl.formatMessage({
+            defaultMessage: "Share my passport",
+            description: "Breadcrumb title.",
+          }),
+        },
       ]}
     >
       <div

--- a/pages/register.tsx
+++ b/pages/register.tsx
@@ -104,11 +104,17 @@ const Register: React.FunctionComponent = () => {
       })}
       crumbs={[
         {
-          title: "Home",
+          title: intl.formatMessage({
+            defaultMessage: "Home",
+            description: "Breadcrumb title.",
+          }),
           href: "/",
         },
         {
-          title: "Register",
+          title: intl.formatMessage({
+            defaultMessage: "Register",
+            description: "Breadcrumb title.",
+          }),
         },
       ]}
       formLayout

--- a/pages/sign-in.tsx
+++ b/pages/sign-in.tsx
@@ -86,11 +86,17 @@ const SignIn: React.FunctionComponent = () => {
       })}
       crumbs={[
         {
-          title: "Home",
+          title: intl.formatMessage({
+            defaultMessage: "Home",
+            description: "Breadcrumb title.",
+          }),
           href: "/",
         },
         {
-          title: "Sign in",
+          title: intl.formatMessage({
+            defaultMessage: "Sign in",
+            description: "Breadcrumb title.",
+          }),
         },
       ]}
       formLayout


### PR DESCRIPTION
Resolves #134.

### Notes
- removes `intl.formatMessage` from strings not requiring translation (emails, proper names)