### PR TITLE
Update Home page links

### DIFF
--- a/components/Home.tsx
+++ b/components/Home.tsx
@@ -32,44 +32,22 @@ const Home: React.FunctionComponent = () => {
     },
     {
       title: intl.formatMessage({
-        defaultMessage: "Passport instructions",
+        defaultMessage: "Library of Barriers and Solutions",
         description: "Employee link text #3",
       }),
       link: intl.formatMessage({
-        defaultMessage:
-          "https://www.gcpedia.gc.ca/gcwiki/images/4/43/Basic_Instructions_updated_Sept_2020_-_GC_Workplace_Accessibility_Passport_Basic_Instructions_(The_7_Steps).docx",
+        defaultMessage: "#",
         description: "Employee link #3",
       }),
     },
     {
       title: intl.formatMessage({
-        defaultMessage: "Frequently Asked Questions (FAQs)",
+        defaultMessage: "Examples of Completed Passports",
         description: "Employee link text #4",
       }),
       link: intl.formatMessage({
-        defaultMessage:
-          "https://www.gcpedia.gc.ca/gcwiki/images/3/36/Passport_-_Frequently-Asked_Questions_(April_2021).docx",
+        defaultMessage: "#",
         description: "Employee link #4",
-      }),
-    },
-    {
-      title: intl.formatMessage({
-        defaultMessage: "Library of Barriers and Solutions",
-        description: "Employee link text #5",
-      }),
-      link: intl.formatMessage({
-        defaultMessage: "#",
-        description: "Employee link #5",
-      }),
-    },
-    {
-      title: intl.formatMessage({
-        defaultMessage: "Examples of Completed Passports",
-        description: "Employee link text #6",
-      }),
-      link: intl.formatMessage({
-        defaultMessage: "#",
-        description: "Employee link #6",
       }),
     },
   ];
@@ -88,44 +66,22 @@ const Home: React.FunctionComponent = () => {
     },
     {
       title: intl.formatMessage({
-        defaultMessage: "Passport guidance",
+        defaultMessage: "Library of Barriers and Solutions",
         description: "Manager link text #2",
       }),
       link: intl.formatMessage({
-        defaultMessage:
-          "https://www.gcpedia.gc.ca/gcwiki/images/4/43/Basic_Instructions_updated_Sept_2020_-_GC_Workplace_Accessibility_Passport_Basic_Instructions_(The_7_Steps).docx",
+        defaultMessage: "#",
         description: "Manager link #2",
       }),
     },
     {
       title: intl.formatMessage({
-        defaultMessage: "Frequently Asked Questions (FAQs)",
+        defaultMessage: "Examples of Completed Passports",
         description: "Manager link text #3",
       }),
       link: intl.formatMessage({
-        defaultMessage:
-          "https://www.gcpedia.gc.ca/gcwiki/images/3/36/Passport_-_Frequently-Asked_Questions_(April_2021).docx",
+        defaultMessage: "#",
         description: "Manager link #3",
-      }),
-    },
-    {
-      title: intl.formatMessage({
-        defaultMessage: "Library of Barriers and Solutions",
-        description: "Manager link text #4",
-      }),
-      link: intl.formatMessage({
-        defaultMessage: "#",
-        description: "Manager link #4",
-      }),
-    },
-    {
-      title: intl.formatMessage({
-        defaultMessage: "Examples of Completed Passports",
-        description: "Manager link text #5",
-      }),
-      link: intl.formatMessage({
-        defaultMessage: "#",
-        description: "Manager link #5",
       }),
     },
   ];

--- a/components/Home.tsx
+++ b/components/Home.tsx
@@ -8,81 +8,42 @@ const Home: React.FunctionComponent = () => {
 
   const employeeLinks = [
     {
-      title: intl.formatMessage({
-        defaultMessage: "GC Workplace Accessibility Passport Canada.ca page",
-        description: "Employee link text #1",
-      }),
-      link: intl.formatMessage({
-        defaultMessage:
-          "https://www.canada.ca/en/government/publicservice/wellness-inclusion-diversity-public-service/diversity-inclusion-public-service/accessibility-public-service/government-canada-workplace-accessibility-passport.html",
-        description: "Employee link #1",
-      }),
+      id: 1,
+      en: "https://www.canada.ca/en/government/publicservice/wellness-inclusion-diversity-public-service/diversity-inclusion-public-service/accessibility-public-service/government-canada-workplace-accessibility-passport.html",
+      fr: "https://www.canada.ca/fr/gouvernement/fonctionpublique/mieux-etre-inclusion-diversite-fonction-publique/diversite-equite-matiere-emploi/accessibilite-fonction-publique/passeport-accessibilite-milieu-travail-gouvernement-canada.html",
     },
     {
-      title: intl.formatMessage({
-        defaultMessage:
-          "GC Workplace Accessibility Passport Rich Text Format Form",
-        description: "Employee link text #2",
-      }),
-      link: intl.formatMessage({
-        defaultMessage:
-          "https://www.canada.ca/content/dam/tbs-sct/documents/accessibility-publi-service/gc-workplace-accessibility-passport-document.rtf",
-        description: "Employee link #2",
-      }),
+      id: 2,
+      en: "https://www.canada.ca/content/dam/tbs-sct/documents/accessibility-publi-service/gc-workplace-accessibility-passport-document.rtf",
+      fr: "https://www.canada.ca/content/dam/tbs-sct/documents/accessibility-publi-service/passeport-pour-laccessibilite-en-milieu-de-travail-du-gc-document.rtf",
     },
     {
-      title: intl.formatMessage({
-        defaultMessage: "Library of Barriers and Solutions",
-        description: "Employee link text #3",
-      }),
-      link: intl.formatMessage({
-        defaultMessage: "#",
-        description: "Employee link #3",
-      }),
+      id: 3,
+      en: "#",
+      fr: "#",
     },
     {
-      title: intl.formatMessage({
-        defaultMessage: "Examples of Completed Passports",
-        description: "Employee link text #4",
-      }),
-      link: intl.formatMessage({
-        defaultMessage: "#",
-        description: "Employee link #4",
-      }),
+      id: 4,
+      en: "#",
+      fr: "#",
     },
   ];
 
   const managerLinks = [
     {
-      title: intl.formatMessage({
-        defaultMessage: "Passport Canada.ca page",
-        description: "Manager link text #1",
-      }),
-      link: intl.formatMessage({
-        defaultMessage:
-          "https://www.gcpedia.gc.ca/gcwiki/images/9/98/GC_Workplace_Accessibility_Passport_Form_(Jan_24_2022).docx",
-        description: "Manager link #1",
-      }),
+      id: 1,
+      en: "https://www.canada.ca/en/government/publicservice/wellness-inclusion-diversity-public-service/diversity-inclusion-public-service/accessibility-public-service/government-canada-workplace-accessibility-passport.html",
+      fr: "https://www.canada.ca/fr/gouvernement/fonctionpublique/mieux-etre-inclusion-diversite-fonction-publique/diversite-equite-matiere-emploi/accessibilite-fonction-publique/passeport-accessibilite-milieu-travail-gouvernement-canada.html",
     },
     {
-      title: intl.formatMessage({
-        defaultMessage: "Library of Barriers and Solutions",
-        description: "Manager link text #2",
-      }),
-      link: intl.formatMessage({
-        defaultMessage: "#",
-        description: "Manager link #2",
-      }),
+      id: 2,
+      en: "#",
+      fr: "#",
     },
     {
-      title: intl.formatMessage({
-        defaultMessage: "Examples of Completed Passports",
-        description: "Manager link text #3",
-      }),
-      link: intl.formatMessage({
-        defaultMessage: "#",
-        description: "Manager link #3",
-      }),
+      id: 3,
+      en: "#",
+      fr: "#",
     },
   ];
 
@@ -253,16 +214,110 @@ const Home: React.FunctionComponent = () => {
                   data-h2-margin="b(bottom-left, m)"
                   style={{ listStyleType: "disc" }}
                 >
-                  {employeeLinks &&
-                    employeeLinks.map(({ title, link }) => (
-                      <li key={title}>
-                        <p>
-                          <Link href={link}>
-                            <a>{title}</a>
-                          </Link>
-                        </p>
-                      </li>
-                    ))}
+                  <li>
+                    <p>
+                      {intl.formatMessage(
+                        {
+                          defaultMessage:
+                            "<link>GC Workplace Accessibility Passport Canada.ca page</link>",
+                          description: "Employee link text #1",
+                        },
+                        {
+                          link: (msg: string) => (
+                            <a
+                              href={
+                                intl.locale === "en"
+                                  ? employeeLinks.find((link) => link.id === 1)
+                                      ?.en
+                                  : employeeLinks.find((link) => link.id === 1)
+                                      ?.fr
+                              }
+                            >
+                              {msg}
+                            </a>
+                          ),
+                        },
+                      )}
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      {intl.formatMessage(
+                        {
+                          defaultMessage:
+                            "<link>GC Workplace Accessibility Passport Rich Text Format Form</link>",
+                          description: "Employee link text #2",
+                        },
+                        {
+                          link: (msg: string) => (
+                            <a
+                              href={
+                                intl.locale === "en"
+                                  ? employeeLinks.find((link) => link.id === 2)
+                                      ?.en
+                                  : employeeLinks.find((link) => link.id === 2)
+                                      ?.fr
+                              }
+                            >
+                              {msg}
+                            </a>
+                          ),
+                        },
+                      )}
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      {intl.formatMessage(
+                        {
+                          defaultMessage:
+                            "<link>Library of Barriers and Solutions</link>",
+                          description: "Employee link text #3",
+                        },
+                        {
+                          link: (msg: string) => (
+                            <a
+                              href={
+                                intl.locale === "en"
+                                  ? employeeLinks.find((link) => link.id === 3)
+                                      ?.en
+                                  : employeeLinks.find((link) => link.id === 3)
+                                      ?.fr
+                              }
+                            >
+                              {msg}
+                            </a>
+                          ),
+                        },
+                      )}
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      {intl.formatMessage(
+                        {
+                          defaultMessage:
+                            "<link>Examples of Completed Passports</link>",
+                          description: "Employee link text #4",
+                        },
+                        {
+                          link: (msg: string) => (
+                            <a
+                              href={
+                                intl.locale === "en"
+                                  ? employeeLinks.find((link) => link.id === 4)
+                                      ?.en
+                                  : employeeLinks.find((link) => link.id === 4)
+                                      ?.fr
+                              }
+                            >
+                              {msg}
+                            </a>
+                          ),
+                        },
+                      )}
+                    </p>
+                  </li>
                 </ul>
                 <p>
                   {intl.formatMessage({
@@ -297,16 +352,84 @@ const Home: React.FunctionComponent = () => {
                   data-h2-margin="b(bottom-left, m)"
                   style={{ listStyleType: "disc" }}
                 >
-                  {managerLinks &&
-                    managerLinks.map(({ title, link }) => (
-                      <li key={title}>
-                        <p>
-                          <Link href={link}>
-                            <a>{title}</a>
-                          </Link>
-                        </p>
-                      </li>
-                    ))}
+                  <li>
+                    <p>
+                      {intl.formatMessage(
+                        {
+                          defaultMessage:
+                            "<link>GC Workplace Accessibility Passport Canada.ca page</link>",
+                          description: "Manager link text #1",
+                        },
+                        {
+                          link: (msg: string) => (
+                            <a
+                              href={
+                                intl.locale === "en"
+                                  ? managerLinks.find((link) => link.id === 1)
+                                      ?.en
+                                  : managerLinks.find((link) => link.id === 1)
+                                      ?.fr
+                              }
+                            >
+                              {msg}
+                            </a>
+                          ),
+                        },
+                      )}
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      {intl.formatMessage(
+                        {
+                          defaultMessage:
+                            "<link>Library of Barriers and Solutions</link>",
+                          description: "Manager link text #2",
+                        },
+                        {
+                          link: (msg: string) => (
+                            <a
+                              href={
+                                intl.locale === "en"
+                                  ? managerLinks.find((link) => link.id === 2)
+                                      ?.en
+                                  : managerLinks.find((link) => link.id === 2)
+                                      ?.fr
+                              }
+                            >
+                              {msg}
+                            </a>
+                          ),
+                        },
+                      )}
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      {intl.formatMessage(
+                        {
+                          defaultMessage:
+                            "<link>Examples of Completed Passports</link>",
+                          description: "Manager link text #3",
+                        },
+                        {
+                          link: (msg: string) => (
+                            <a
+                              href={
+                                intl.locale === "en"
+                                  ? managerLinks.find((link) => link.id === 3)
+                                      ?.en
+                                  : managerLinks.find((link) => link.id === 3)
+                                      ?.fr
+                              }
+                            >
+                              {msg}
+                            </a>
+                          ),
+                        },
+                      )}
+                    </p>
+                  </li>
                 </ul>
               </div>
             </div>

--- a/components/Home.tsx
+++ b/components/Home.tsx
@@ -1,9 +1,135 @@
+import Link from "next/link";
 import * as React from "react";
 import { useIntl } from "react-intl";
 import { strong } from "../helpers/format";
 
 const Home: React.FunctionComponent = () => {
   const intl = useIntl();
+
+  const employeeLinks = [
+    {
+      title: intl.formatMessage({
+        defaultMessage: "GC Workplace Accessibility Passport Canada.ca page",
+        description: "Employee link text #1",
+      }),
+      link: intl.formatMessage({
+        defaultMessage:
+          "https://www.canada.ca/en/government/publicservice/wellness-inclusion-diversity-public-service/diversity-inclusion-public-service/accessibility-public-service/government-canada-workplace-accessibility-passport.html",
+        description: "Employee link #1",
+      }),
+    },
+    {
+      title: intl.formatMessage({
+        defaultMessage:
+          "GC Workplace Accessibility Passport Rich Text Format Form",
+        description: "Employee link text #2",
+      }),
+      link: intl.formatMessage({
+        defaultMessage:
+          "https://www.canada.ca/content/dam/tbs-sct/documents/accessibility-publi-service/gc-workplace-accessibility-passport-document.rtf",
+        description: "Employee link #2",
+      }),
+    },
+    {
+      title: intl.formatMessage({
+        defaultMessage: "Passport instructions",
+        description: "Employee link text #3",
+      }),
+      link: intl.formatMessage({
+        defaultMessage:
+          "https://www.gcpedia.gc.ca/gcwiki/images/4/43/Basic_Instructions_updated_Sept_2020_-_GC_Workplace_Accessibility_Passport_Basic_Instructions_(The_7_Steps).docx",
+        description: "Employee link #3",
+      }),
+    },
+    {
+      title: intl.formatMessage({
+        defaultMessage: "Frequently Asked Questions (FAQs)",
+        description: "Employee link text #4",
+      }),
+      link: intl.formatMessage({
+        defaultMessage:
+          "https://www.gcpedia.gc.ca/gcwiki/images/3/36/Passport_-_Frequently-Asked_Questions_(April_2021).docx",
+        description: "Employee link #4",
+      }),
+    },
+    {
+      title: intl.formatMessage({
+        defaultMessage: "Library of Barriers and Solutions",
+        description: "Employee link text #5",
+      }),
+      link: intl.formatMessage({
+        defaultMessage: "#",
+        description: "Employee link #5",
+      }),
+    },
+    {
+      title: intl.formatMessage({
+        defaultMessage: "Examples of Completed Passports",
+        description: "Employee link text #6",
+      }),
+      link: intl.formatMessage({
+        defaultMessage: "#",
+        description: "Employee link #6",
+      }),
+    },
+  ];
+
+  const managerLinks = [
+    {
+      title: intl.formatMessage({
+        defaultMessage: "Passport Canada.ca page",
+        description: "Manager link text #1",
+      }),
+      link: intl.formatMessage({
+        defaultMessage:
+          "https://www.gcpedia.gc.ca/gcwiki/images/9/98/GC_Workplace_Accessibility_Passport_Form_(Jan_24_2022).docx",
+        description: "Manager link #1",
+      }),
+    },
+    {
+      title: intl.formatMessage({
+        defaultMessage: "Passport guidance",
+        description: "Manager link text #2",
+      }),
+      link: intl.formatMessage({
+        defaultMessage:
+          "https://www.gcpedia.gc.ca/gcwiki/images/4/43/Basic_Instructions_updated_Sept_2020_-_GC_Workplace_Accessibility_Passport_Basic_Instructions_(The_7_Steps).docx",
+        description: "Manager link #2",
+      }),
+    },
+    {
+      title: intl.formatMessage({
+        defaultMessage: "Frequently Asked Questions (FAQs)",
+        description: "Manager link text #3",
+      }),
+      link: intl.formatMessage({
+        defaultMessage:
+          "https://www.gcpedia.gc.ca/gcwiki/images/3/36/Passport_-_Frequently-Asked_Questions_(April_2021).docx",
+        description: "Manager link #3",
+      }),
+    },
+    {
+      title: intl.formatMessage({
+        defaultMessage: "Library of Barriers and Solutions",
+        description: "Manager link text #4",
+      }),
+      link: intl.formatMessage({
+        defaultMessage: "#",
+        description: "Manager link #4",
+      }),
+    },
+    {
+      title: intl.formatMessage({
+        defaultMessage: "Examples of Completed Passports",
+        description: "Manager link text #5",
+      }),
+      link: intl.formatMessage({
+        defaultMessage: "#",
+        description: "Manager link #5",
+      }),
+    },
+  ];
+
   return (
     <section>
       <div data-h2-display="b(flex)" data-h2-flex-direction="b(column) s(row)">
@@ -171,61 +297,16 @@ const Home: React.FunctionComponent = () => {
                   data-h2-margin="b(bottom-left, m)"
                   style={{ listStyleType: "disc" }}
                 >
-                  <li>
-                    <p>
-                      <a href="#">
-                        {intl.formatMessage({
-                          defaultMessage: "Passport Canada.ca page",
-                        })}
-                      </a>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <a href="https://www.gcpedia.gc.ca/gcwiki/images/9/98/GC_Workplace_Accessibility_Passport_Form_(Jan_24_2022).docx">
-                        {intl.formatMessage({
-                          defaultMessage:
-                            "GC Workplace Accessibility Passport Form (Word Version)",
-                        })}
-                      </a>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <a href="https://www.gcpedia.gc.ca/gcwiki/images/4/43/Basic_Instructions_updated_Sept_2020_-_GC_Workplace_Accessibility_Passport_Basic_Instructions_(The_7_Steps).docx">
-                        {intl.formatMessage({
-                          defaultMessage: "Passport instructions",
-                        })}
-                      </a>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <a href="https://www.gcpedia.gc.ca/gcwiki/images/3/36/Passport_-_Frequently-Asked_Questions_(April_2021).docx">
-                        {intl.formatMessage({
-                          defaultMessage: "Frequently Asked Questions (FAQs)",
-                        })}
-                      </a>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <a href="#">
-                        {intl.formatMessage({
-                          defaultMessage: "Library of Barriers and Solutions",
-                        })}
-                      </a>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <a href="#">
-                        {intl.formatMessage({
-                          defaultMessage: "Examples of Completed Passports",
-                        })}
-                      </a>
-                    </p>
-                  </li>
+                  {employeeLinks &&
+                    employeeLinks.map(({ title, link }) => (
+                      <li key={title}>
+                        <p>
+                          <Link href={link}>
+                            <a>{title}</a>
+                          </Link>
+                        </p>
+                      </li>
+                    ))}
                 </ul>
                 <p>
                   {intl.formatMessage({
@@ -260,51 +341,16 @@ const Home: React.FunctionComponent = () => {
                   data-h2-margin="b(bottom-left, m)"
                   style={{ listStyleType: "disc" }}
                 >
-                  <li>
-                    <p>
-                      <a href="#">
-                        {intl.formatMessage({
-                          defaultMessage: "Passport Canada.ca page",
-                        })}
-                      </a>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <a href="https://www.gcpedia.gc.ca/gcwiki/images/b/b1/Guidance_updated_Sept_2020_-_GC_Workplace_Accessibility_Passport_General_Guidance_.docx">
-                        {intl.formatMessage({
-                          defaultMessage: "Passport guidance",
-                        })}
-                      </a>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <a href="https://www.gcpedia.gc.ca/gcwiki/images/3/36/Passport_-_Frequently-Asked_Questions_(April_2021).docx">
-                        {intl.formatMessage({
-                          defaultMessage: "Frequently Asked Questions (FAQs)",
-                        })}
-                      </a>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <a href="#">
-                        {intl.formatMessage({
-                          defaultMessage: "Library of Barriers and Solutions",
-                        })}
-                      </a>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <a href="#">
-                        {intl.formatMessage({
-                          defaultMessage: "Examples of Completed Passports",
-                        })}
-                      </a>
-                    </p>
-                  </li>
+                  {managerLinks &&
+                    managerLinks.map(({ title, link }) => (
+                      <li key={title}>
+                        <p>
+                          <Link href={link}>
+                            <a>{title}</a>
+                          </Link>
+                        </p>
+                      </li>
+                    ))}
                 </ul>
               </div>
             </div>

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1155,7 +1155,7 @@
     "description": "Manager link text #5"
   },
   "hZZaJn": {
-    "defaultMessage": "Page Canada.ca Passeport pour l'accessibilté en milieu de travail",
+    "defaultMessage": "Page Canada.ca Passeport pour l’accessibilité en milieu de travail",
     "description": "Employee link text #1"
   },
   "mxXiw9": {

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1114,22 +1114,6 @@
     "defaultMessage": "Renseignements d’urgence",
     "description": "Breadcrumb title."
   },
-  "/UqgOs": {
-    "defaultMessage": "Instructions du passeport",
-    "description": "Employee link text #3"
-  },
-  "1PLyRX": {
-    "defaultMessage": "Guide du passeport",
-    "description": "Manager link text #2"
-  },
-  "Co+y3a": {
-    "defaultMessage": "Foire aux questions (FAQ)",
-    "description": "Manager link text #3"
-  },
-  "HYyxhX": {
-    "defaultMessage": "Bibliothèque d’obstacles et de solutions",
-    "description": "Employee link text #5"
-  },
   "J7+Hl0": {
     "defaultMessage": "Passeport pour l'accessibilité en milieu de travail version rtf",
     "description": "Employee link text #2"
@@ -1138,32 +1122,36 @@
     "defaultMessage": "https://www.canada.ca/fr/gouvernement/fonctionpublique/mieux-etre-inclusion-diversite-fonction-publique/diversite-equite-matiere-emploi/accessibilite-fonction-publique/passeport-accessibilite-milieu-travail-gouvernement-canada.html",
     "description": "Employee link #1"
   },
-  "P5+Zjh": {
-    "defaultMessage": "Bibliothèque d’obstacles et de solutions",
-    "description": "Manager link text #4"
-  },
   "SaDNJW": {
     "defaultMessage": "https://www.canada.ca/content/dam/tbs-sct/documents/accessibility-publi-service/passeport-pour-laccessibilite-en-milieu-de-travail-du-gc-document.rtf",
     "description": "Employee link #2"
-  },
-  "T4gD7Q": {
-    "defaultMessage": "Foire aux questions (FAQ)",
-    "description": "Employee link text #4"
-  },
-  "gfL0+v": {
-    "defaultMessage": "Exemples de passeports remplis",
-    "description": "Manager link text #5"
   },
   "hZZaJn": {
     "defaultMessage": "Page Canada.ca Passeport pour l’accessibilité en milieu de travail",
     "description": "Employee link text #1"
   },
-  "mxXiw9": {
-    "defaultMessage": "Exemples de passeports remplis",
-    "description": "Employee link text #6"
-  },
   "rBlC6E": {
     "defaultMessage": "Page Passeport Canada.ca",
     "description": "Manager link text #1"
+  },
+  "ZsyH8c": {
+    "defaultMessage": "https://www.canada.ca/fr/gouvernement/fonctionpublique/mieux-etre-inclusion-diversite-fonction-publique/diversite-equite-matiere-emploi/accessibilite-fonction-publique/passeport-accessibilite-milieu-travail-gouvernement-canada.html",
+    "description": "Manager link #1"
+  },
+  "GcLfbO": {
+    "defaultMessage": "Bibliothèque d’obstacles et de solutions",
+    "description": "Employee link text #3"
+  },
+  "QuCxX9": {
+    "defaultMessage": "Exemples de passeports remplis",
+    "description": "Manager link text #3"
+  },
+  "mzJorh": {
+    "defaultMessage": "Bibliothèque d’obstacles et de solutions",
+    "description": "Manager link text #2"
+  },
+  "qp/alT": {
+    "defaultMessage": "Exemples de passeports remplis",
+    "description": "Employee link text #4"
   }
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -348,9 +348,6 @@
   "+i6kfV": {
     "defaultMessage": "Sélectionnez un rôle"
   },
-  "+p4ntU": {
-    "defaultMessage": "Page Passeport Canada.ca"
-  },
   "/VnDMl": {
     "defaultMessage": "Autre"
   },
@@ -389,9 +386,6 @@
   },
   "3wbEhz": {
     "defaultMessage": "Sélectionnez une ou plusieurs situations..."
-  },
-  "4+pQMC": {
-    "defaultMessage": "Instructions du passeport"
   },
   "47FYwb": {
     "defaultMessage": "Annuler"
@@ -517,9 +511,6 @@
   },
   "G5RVE2": {
     "defaultMessage": "Consignez l’accord entre vous et votre gestionnaire concernant les outils ou les mesures d’adaptation du milieu de travail à fournir."
-  },
-  "H96byv": {
-    "defaultMessage": "Foire aux questions (FAQ)"
   },
   "HBqCn/": {
     "defaultMessage": "Courriel actuel"
@@ -651,17 +642,11 @@
     "defaultMessage": "Politique de confidentialité",
     "description": "Label for the privacy link in the Footer."
   },
-  "W8Fkfw": {
-    "defaultMessage": "Guide du passeport"
-  },
   "YTDh7Q": {
     "defaultMessage": "Aucune obstacle trouvée."
   },
   "YXH1/n": {
     "defaultMessage": "Sélectionnez l’un des liens ci-dessous pour enregistrer votre obstacle et la consulter; ou pour l’enregistrer et en ajouter une autre."
-  },
-  "Z5EN8d": {
-    "defaultMessage": "Formulaire du Passeport pour l’accessibilité en milieu de travail du GC (Version Word)"
   },
   "ZE77nf": {
     "defaultMessage": "Canada.ca",
@@ -747,9 +732,6 @@
   },
   "lPiStM": {
     "defaultMessage": "Gérer votre compte - Passeport pour l’accessibilité en milieu de travail du GC"
-  },
-  "lZp3ZB": {
-    "defaultMessage": "Exemples de passeports remplis"
   },
   "lxbsBd": {
     "defaultMessage": "Accueil",
@@ -856,9 +838,6 @@
   },
   "1PKZnN": {
     "defaultMessage": "Identifier un obstacle. Un obstacle signifie tout ce qui vous empêche d’accomplir vos tâches dans votre environnement de travail. Aux fins de remplir le Passeport, un obstacle peut être spécifique au travail ou à une tâche."
-  },
-  "1YMdPR": {
-    "defaultMessage": "Bibliothèque d’obstacles et de solutions"
   },
   "1erloT": {
     "defaultMessage": "Communiquer avec un gestionnaire de cas ou un professionnel de l'adaptation en milieu de travail"
@@ -1134,5 +1113,57 @@
   "yP48k+": {
     "defaultMessage": "Renseignements d’urgence",
     "description": "Breadcrumb title."
+  },
+  "/UqgOs": {
+    "defaultMessage": "Instructions du passeport",
+    "description": "Employee link text #3"
+  },
+  "1PLyRX": {
+    "defaultMessage": "Guide du passeport",
+    "description": "Manager link text #2"
+  },
+  "Co+y3a": {
+    "defaultMessage": "Foire aux questions (FAQ)",
+    "description": "Manager link text #3"
+  },
+  "HYyxhX": {
+    "defaultMessage": "Bibliothèque d’obstacles et de solutions",
+    "description": "Employee link text #5"
+  },
+  "J7+Hl0": {
+    "defaultMessage": "Passeport pour l'accessibilité en milieu de travail version rtf",
+    "description": "Employee link text #2"
+  },
+  "KTXCII": {
+    "defaultMessage": "https://www.canada.ca/fr/gouvernement/fonctionpublique/mieux-etre-inclusion-diversite-fonction-publique/diversite-equite-matiere-emploi/accessibilite-fonction-publique/passeport-accessibilite-milieu-travail-gouvernement-canada.html",
+    "description": "Employee link #1"
+  },
+  "P5+Zjh": {
+    "defaultMessage": "Bibliothèque d’obstacles et de solutions",
+    "description": "Manager link text #4"
+  },
+  "SaDNJW": {
+    "defaultMessage": "https://www.canada.ca/content/dam/tbs-sct/documents/accessibility-publi-service/passeport-pour-laccessibilite-en-milieu-de-travail-du-gc-document.rtf",
+    "description": "Employee link #2"
+  },
+  "T4gD7Q": {
+    "defaultMessage": "Foire aux questions (FAQ)",
+    "description": "Employee link text #4"
+  },
+  "gfL0+v": {
+    "defaultMessage": "Exemples de passeports remplis",
+    "description": "Manager link text #5"
+  },
+  "hZZaJn": {
+    "defaultMessage": "Page Canada.ca Passeport pour l'accessibilté en milieu de travail",
+    "description": "Employee link text #1"
+  },
+  "mxXiw9": {
+    "defaultMessage": "Exemples de passeports remplis",
+    "description": "Employee link text #6"
+  },
+  "rBlC6E": {
+    "defaultMessage": "Page Passeport Canada.ca",
+    "description": "Manager link text #1"
   }
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1114,44 +1114,32 @@
     "defaultMessage": "Renseignements d’urgence",
     "description": "Breadcrumb title."
   },
-  "J7+Hl0": {
-    "defaultMessage": "Passeport pour l'accessibilité en milieu de travail version rtf",
-    "description": "Employee link text #2"
-  },
-  "KTXCII": {
-    "defaultMessage": "https://www.canada.ca/fr/gouvernement/fonctionpublique/mieux-etre-inclusion-diversite-fonction-publique/diversite-equite-matiere-emploi/accessibilite-fonction-publique/passeport-accessibilite-milieu-travail-gouvernement-canada.html",
-    "description": "Employee link #1"
-  },
-  "SaDNJW": {
-    "defaultMessage": "https://www.canada.ca/content/dam/tbs-sct/documents/accessibility-publi-service/passeport-pour-laccessibilite-en-milieu-de-travail-du-gc-document.rtf",
-    "description": "Employee link #2"
-  },
-  "hZZaJn": {
-    "defaultMessage": "Page Canada.ca Passeport pour l’accessibilité en milieu de travail",
-    "description": "Employee link text #1"
-  },
-  "rBlC6E": {
-    "defaultMessage": "Page Passeport Canada.ca",
-    "description": "Manager link text #1"
-  },
-  "ZsyH8c": {
-    "defaultMessage": "https://www.canada.ca/fr/gouvernement/fonctionpublique/mieux-etre-inclusion-diversite-fonction-publique/diversite-equite-matiere-emploi/accessibilite-fonction-publique/passeport-accessibilite-milieu-travail-gouvernement-canada.html",
-    "description": "Manager link #1"
-  },
-  "GcLfbO": {
-    "defaultMessage": "Bibliothèque d’obstacles et de solutions",
+  "2SSY8y": {
+    "defaultMessage": "<link>Bibliothèque d’obstacles et de solutions</link>",
     "description": "Employee link text #3"
   },
-  "QuCxX9": {
-    "defaultMessage": "Exemples de passeports remplis",
+  "Ej1vgT": {
+    "defaultMessage": "<link>Passeport pour l'accessibilité en milieu de travail version rtf</link>",
+    "description": "Employee link text #2"
+  },
+  "Kt+d4+": {
+    "defaultMessage": "<link>Exemples de passeports remplis</link>",
     "description": "Manager link text #3"
   },
-  "mzJorh": {
-    "defaultMessage": "Bibliothèque d’obstacles et de solutions",
+  "Sb+Ubj": {
+    "defaultMessage": "<link>Page Canada.ca Passeport pour l’accessibilité en milieu de travail</link>",
+    "description": "Manager link text #1"
+  },
+  "TcG1eq": {
+    "defaultMessage": "<link>Page Canada.ca Passeport pour l’accessibilité en milieu de travail</link>",
+    "description": "Employee link text #1"
+  },
+  "c4+KYd": {
+    "defaultMessage": "<link>Bibliothèque d’obstacles et de solutions</link>",
     "description": "Manager link text #2"
   },
-  "qp/alT": {
-    "defaultMessage": "Exemples de passeports remplis",
+  "k9aMGd": {
+    "defaultMessage": "<link>Exemples de passeports remplis</link>",
     "description": "Employee link text #4"
   }
 }


### PR DESCRIPTION
Resolves #182, #185.

### Note
We are [missing some of the URLs](https://github.com/GCTC-NTGC/gc-accessibility-passport/issues/185) but the [decision has been made](https://github.com/GCTC-NTGC/gc-accessibility-passport/pull/186#issuecomment-1155706217) to leave them as placeholder `#` for now.