### PR TITLE
Add custom css for button blue solid focus

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -11,6 +11,8 @@ export interface ButtonProps extends React.HTMLProps<HTMLButtonElement> {
   block?: boolean;
   /** Get access to the DOM element by passing a react ref.  */
   innerRef?: React.LegacyRef<HTMLButtonElement>;
+  /** The class of button. */
+  className?: string | undefined;
 }
 
 export const colorMap: Record<
@@ -108,6 +110,9 @@ export const Button: React.FC<ButtonProps> = ({
         overflowWrap: "break-word",
         width: block ? "100%" : "auto",
       }}
+      className={
+        color === "blue" && mode === "solid" ? "button-blue-solid" : ""
+      }
       ref={innerRef}
       {...rest}
     >

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -130,6 +130,7 @@ const AccountManagement: React.FunctionComponent = () => {
               data-h2-text-align="b(center)"
               data-h2-radius="b(s)"
               data-h2-margin="b(bottom, m)"
+              className="button-blue-solid"
             >
               {intl.formatMessage({
                 defaultMessage: "Reset my password",
@@ -145,6 +146,7 @@ const AccountManagement: React.FunctionComponent = () => {
               data-h2-text-align="b(center)"
               data-h2-radius="b(s)"
               data-h2-margin="b(bottom, m)"
+              className="button-blue-solid"
             >
               {intl.formatMessage({
                 defaultMessage: "Download my data",
@@ -160,6 +162,7 @@ const AccountManagement: React.FunctionComponent = () => {
               data-h2-text-align="b(center)"
               data-h2-radius="b(s)"
               data-h2-margin="b(bottom, m)"
+              className="button-blue-solid"
             >
               {intl.formatMessage({
                 defaultMessage: "Delete my account",

--- a/pages/manager/manager-dashboard.tsx
+++ b/pages/manager/manager-dashboard.tsx
@@ -132,6 +132,7 @@ const ManagerDashboard: React.FunctionComponent = () => {
                 data-h2-text-align="b(center)"
                 data-h2-radius="b(s)"
                 data-h2-margin="b(bottom, m)"
+                className="button-blue-solid"
               >
                 {intl.formatMessage({
                   defaultMessage: "Get in touch",
@@ -160,6 +161,7 @@ const ManagerDashboard: React.FunctionComponent = () => {
                 data-h2-radius="b(s)"
                 target="_blank"
                 rel="noopener noreferrer"
+                className="button-blue-solid"
               >
                 {intl.formatMessage({
                   defaultMessage: "Contact the AAACT",

--- a/pages/passport/barriers/review-barrier.tsx
+++ b/pages/passport/barriers/review-barrier.tsx
@@ -230,6 +230,7 @@ const ReviewBarrier: React.FunctionComponent = () => {
                 data-h2-radius="b(s)"
                 data-h2-display="b(block)"
                 data-h2-margin="b(bottom, m)"
+                className="button-blue-solid"
               >
                 {intl.formatMessage({
                   defaultMessage: "Edit my Barrier Information",
@@ -245,6 +246,7 @@ const ReviewBarrier: React.FunctionComponent = () => {
                 data-h2-radius="b(s)"
                 data-h2-display="b(block)"
                 data-h2-margin="b(bottom, m)"
+                className="button-blue-solid"
               >
                 {intl.formatMessage({
                   defaultMessage: "Identify another solution for this barrier",
@@ -313,6 +315,7 @@ const ReviewBarrier: React.FunctionComponent = () => {
                 data-h2-radius="b(s)"
                 data-h2-display="b(block)"
                 data-h2-margin="b(top-bottom, m)"
+                className="button-blue-solid"
               >
                 {intl.formatMessage({
                   defaultMessage: "Share with another person",

--- a/pages/passport/barriers/solutions/identify-a-solution-2.tsx
+++ b/pages/passport/barriers/solutions/identify-a-solution-2.tsx
@@ -226,6 +226,7 @@ const IdentifyASolution2: React.FunctionComponent = () => {
                 data-h2-text-align="b(center)"
                 data-h2-radius="b(s)"
                 data-h2-margin="b(right, m)"
+                className="button-blue-solid"
               >
                 {intl.formatMessage({
                   defaultMessage: "Save and add another solution",

--- a/pages/passport/barriers/solutions/review-solution.tsx
+++ b/pages/passport/barriers/solutions/review-solution.tsx
@@ -242,6 +242,7 @@ const ViewSolution: React.FunctionComponent = () => {
                 data-h2-padding="b(all, s)"
                 data-h2-radius="b(s)"
                 data-h2-display="b(inline-block)"
+                className="button-blue-solid"
               >
                 {intl.formatMessage({
                   defaultMessage: "Edit this solution's information",

--- a/pages/passport/emergency-info.tsx
+++ b/pages/passport/emergency-info.tsx
@@ -283,6 +283,7 @@ const EmergencyInfo: React.FunctionComponent = () => {
                 data-h2-radius="b(s)"
                 data-h2-display="b(block)"
                 data-h2-margin="b(top-bottom, m)"
+                className="button-blue-solid"
               >
                 {intl.formatMessage({
                   defaultMessage: "Share with someone new",

--- a/pages/passport/index.tsx
+++ b/pages/passport/index.tsx
@@ -89,6 +89,7 @@ const Passport: React.FunctionComponent = () => {
                   data-h2-justify-content="b(center)"
                   data-h2-text-align="b(center)"
                   data-h2-radius="b(s)"
+                  className="button-blue-solid"
                 >
                   {intl.formatMessage({
                     defaultMessage: "Identify another barrier",
@@ -106,6 +107,7 @@ const Passport: React.FunctionComponent = () => {
                   data-h2-justify-content="b(center)"
                   data-h2-text-align="b(center)"
                   data-h2-radius="b(s)"
+                  className="button-blue-solid"
                 >
                   {intl.formatMessage({
                     defaultMessage: "Share my passport information",
@@ -123,6 +125,7 @@ const Passport: React.FunctionComponent = () => {
                   data-h2-justify-content="b(center)"
                   data-h2-text-align="b(center)"
                   data-h2-radius="b(s)"
+                  className="button-blue-solid"
                 >
                   {intl.formatMessage({
                     defaultMessage: "Manage permissions",
@@ -260,6 +263,7 @@ const Passport: React.FunctionComponent = () => {
                     data-h2-radius="b(s)"
                     data-h2-display="b(block)"
                     data-h2-margin="b(bottom, m)"
+                    className="button-blue-solid"
                   >
                     {intl.formatMessage({
                       defaultMessage: "Edit emergency info",
@@ -296,6 +300,7 @@ const Passport: React.FunctionComponent = () => {
                     data-h2-radius="b(s)"
                     data-h2-display="b(block)"
                     data-h2-margin="b(bottom, m)"
+                    className="button-blue-solid"
                   >
                     {intl.formatMessage({
                       defaultMessage: "Edit manager information",
@@ -360,6 +365,7 @@ const Passport: React.FunctionComponent = () => {
                 data-h2-text-align="b(center)"
                 data-h2-radius="b(s)"
                 data-h2-margin="b(bottom, m)"
+                className="button-blue-solid"
               >
                 {intl.formatMessage({
                   defaultMessage: "Get in touch",
@@ -388,6 +394,7 @@ const Passport: React.FunctionComponent = () => {
                 data-h2-radius="b(s)"
                 target="_blank"
                 rel="noopener noreferrer"
+                className="button-blue-solid"
               >
                 {intl.formatMessage({
                   defaultMessage: "Contact the AAACT",

--- a/pages/passport/manage-permissions.tsx
+++ b/pages/passport/manage-permissions.tsx
@@ -109,6 +109,7 @@ const ManagePermissions: React.FunctionComponent = () => {
                 data-h2-radius="b(s)"
                 data-h2-display="b(block)"
                 data-h2-margin="b(bottom, m)"
+                className="button-blue-solid"
               >
                 {intl.formatMessage({
                   defaultMessage: "Share with another person",
@@ -130,6 +131,7 @@ const ManagePermissions: React.FunctionComponent = () => {
                 data-h2-radius="b(s)"
                 data-h2-display="b(block)"
                 data-h2-margin="b(bottom, m)"
+                className="button-blue-solid"
               >
                 {intl.formatMessage({
                   defaultMessage: "Edit my manager information",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -23,6 +23,10 @@ ul {
   padding: 0;
 }
 
+.button-blue-solid:focus {
+  box-shadow: 0 0 0 3px white, 0 0 0 6px #22598A;
+}
+
 .center {
   position: absolute;
   top: 50%;


### PR DESCRIPTION
Resolves #114.

### Description
Styling applies to `a` and `button` elements with blue solid color map. Class name needed to be added as inline style not possible for **focus** pseudo-class.

### Screenshot
![Screen Shot 2022-06-20 at 12 44 20](https://user-images.githubusercontent.com/3046459/174647429-23afbed6-6f08-460b-9b14-65b779b19181.png)