### PR TITLE
Divide verb and noun with colon

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1139,12 +1139,12 @@
     "defaultMessage": "<link>Exemples de passeports remplis</link>",
     "description": "Employee link text #4"
   },
-  "rRlGQb": {
-    "defaultMessage": "Afficher le passeport de {name}",
-    "description": "Passport card link text"
-  },
-  "aU+8uX": {
-    "defaultMessage": "Afficher {name}",
+  "UhZuDF": {
+    "defaultMessage": "Afficher : {name}",
     "description": "Passport card barrier link text"
+  },
+  "d00qHv": {
+    "defaultMessage": "Afficher le passeport de : {name}",
+    "description": "Passport card link text"
   }
 }

--- a/pages/manager/manager-dashboard.tsx
+++ b/pages/manager/manager-dashboard.tsx
@@ -67,7 +67,7 @@ const ManagerDashboard: React.FunctionComponent = () => {
                   link={{
                     title: intl.formatMessage(
                       {
-                        defaultMessage: "View {name}'s passport",
+                        defaultMessage: "View: {name}'s passport",
                         description: "Passport card link text",
                       },
                       { name },

--- a/pages/passport/index.tsx
+++ b/pages/passport/index.tsx
@@ -154,7 +154,7 @@ const Passport: React.FunctionComponent = () => {
                       link={{
                         title: intl.formatMessage(
                           {
-                            defaultMessage: "View {name}",
+                            defaultMessage: "View: {name}",
                             description: "Passport card barrier link text",
                           },
                           {


### PR DESCRIPTION
Resolves #189.

### Description
Divide verb and noun with colon to avoid awkward screen reader sentences.