### PR TITLE
Add AlertDialog component; Update SelectRoleDialog component

### DIFF
--- a/components/AlertDialog/AlertDialog.tsx
+++ b/components/AlertDialog/AlertDialog.tsx
@@ -1,0 +1,78 @@
+import {
+  AlertDialogOverlay,
+  AlertDialogContent,
+  AlertDialogLabel,
+  AlertDialogDescription,
+} from "@reach/alert-dialog";
+import React, { RefObject } from "react";
+
+export interface AlertDialogProps {
+  isOpen: boolean;
+  title: string;
+  centered?: boolean;
+  footer?: React.ReactNode;
+  leastDestructiveRef?: RefObject<HTMLElement> | undefined;
+}
+
+const AlertDialog: React.FC<AlertDialogProps> = ({
+  isOpen,
+  title,
+  centered = false,
+  footer,
+  children,
+}) => {
+  const leastDestructiveRef = React.useRef<HTMLButtonElement | null>(null);
+  return (
+    <div>
+      {isOpen && (
+        <AlertDialogOverlay
+          data-h2-bg-color="b(black[.85])"
+          leastDestructiveRef={leastDestructiveRef}
+        >
+          <AlertDialogContent
+            data-h2-bg-color="b(white)"
+            data-h2-margin="b(top-bottom, xxl)"
+            data-h2-position="b(relative)"
+            data-h2-radius="b(s)"
+            data-h2-shadow="b(s)"
+            className={centered ? `alert-dialog--centered` : undefined}
+          >
+            <div
+              className="alert-dialog__header"
+              data-h2-bg-color="b(blue)"
+              data-h2-radius="b(s, s, none, none)"
+              data-h2-padding="b(all, m)"
+              data-h2-position="b(relative)"
+            >
+              <AlertDialogLabel>
+                <h1
+                  data-h2-font-color="b(white)"
+                  data-h2-font-weight="b(700)"
+                  data-h2-font-size="b(h3)"
+                  data-h2-margin="b(all, none)"
+                >
+                  {title}
+                </h1>
+              </AlertDialogLabel>
+            </div>
+            <AlertDialogDescription className="alert-dialog__content">
+              {children}
+            </AlertDialogDescription>
+            {footer ? (
+              <div
+                className="alert-dialog__footer"
+                data-h2-margin="b(top, m)"
+                data-h2-padding="b(top, m)"
+                data-h2-border="b(darkgray, top, solid, s)"
+              >
+                {footer}
+              </div>
+            ) : null}
+          </AlertDialogContent>
+        </AlertDialogOverlay>
+      )}
+    </div>
+  );
+};
+
+export default AlertDialog;

--- a/components/AlertDialog/index.ts
+++ b/components/AlertDialog/index.ts
@@ -1,0 +1,5 @@
+import AlertDialog from "./AlertDialog";
+import type { AlertDialogProps } from "./AlertDialog";
+
+export default AlertDialog;
+export type { AlertDialogProps };

--- a/components/SelectRoleDialog.tsx
+++ b/components/SelectRoleDialog.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useIntl } from "react-intl";
 import Button from "./Button";
-import Dialog from "./Dialog";
+import AlertDialog from "./AlertDialog";
 
 interface SelectRoleDialogProps {
   isOpen: boolean;
@@ -15,10 +15,7 @@ const SelectRoleDialog: React.FunctionComponent<SelectRoleDialogProps> = ({
   const intl = useIntl();
   return (
     <>
-      <Dialog
-        onDismiss={() => {
-          /* do nothing */
-        }}
+      <AlertDialog
         isOpen={isOpen}
         title={intl.formatMessage({ defaultMessage: "Select a role" })}
         footer={
@@ -78,7 +75,7 @@ const SelectRoleDialog: React.FunctionComponent<SelectRoleDialogProps> = ({
               "You can switch roles at any time using the link in the main site navigation.",
           })}
         </p>
-      </Dialog>
+      </AlertDialog>
     </>
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "gc-accessibility-passport",
       "dependencies": {
         "@heroicons/react": "^1.0.6",
+        "@reach/alert-dialog": "^0.17.0",
         "@reach/dialog": "^0.17.0",
         "iron-session": "^6.0.5",
         "json-loader": "^0.5.7",
@@ -72,11 +73,11 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
-      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
       "dependencies": {
-        "@babel/highlight": "^7.16.7"
+        "@babel/highlight": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -293,9 +294,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -322,11 +323,11 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.16.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
-      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -369,12 +370,12 @@
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -382,7 +383,7 @@
     "node_modules/@babel/highlight/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "engines": {
         "node": ">=4"
       }
@@ -399,9 +400,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.17.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.3.tgz",
-      "integrity": "sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.6.tgz",
+      "integrity": "sha512-uQVSa9jJUe/G/304lXspfWVpKpK4euFLgGiMQFOCpM/bgcAdeoHwi/OQz23O9GK2osz26ZiXRRV9aV+Yl1O8tw==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -447,6 +448,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/template": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.6.tgz",
+      "integrity": "sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==",
+      "dependencies": {
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.18.6",
+        "@babel/types": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/traverse": {
       "version": "7.17.3",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
@@ -476,11 +490,11 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
-      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.6.tgz",
+      "integrity": "sha512-NdBNzPDwed30fZdDQtVR7ZgaO4UKjuaQFH9VArS+HMnurlOY0JWN+4ROlu/iapMFwjRQU4pOG4StZfDmulEwGA==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -1493,6 +1507,46 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-5.2.0.tgz",
       "integrity": "sha512-OZhKy1w8/GF4GWtdiJc+o8sloWAHRueGB78FWFLZnueK7EHV9MzDVr4weJZMflJwMK4uuYLzcnJVnAoy3yB35g=="
+    },
+    "node_modules/@reach/alert-dialog": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/alert-dialog/-/alert-dialog-0.17.0.tgz",
+      "integrity": "sha512-qJOp9JE2Jv8ALUhq5yJrrGITk1YCkkDFlqejI19qeAXsuQ/ZIKzeiDYSih+avb+1mfV4HEzB9WoVJWcRTOwjiQ==",
+      "dependencies": {
+        "@reach/auto-id": "0.17.0",
+        "@reach/dialog": "0.17.0",
+        "@reach/utils": "0.17.0",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.7.2",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@reach/alert-dialog/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
+    "node_modules/@reach/auto-id": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.17.0.tgz",
+      "integrity": "sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==",
+      "dependencies": {
+        "@reach/utils": "0.17.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@reach/auto-id/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@reach/dialog": {
       "version": "0.17.0",
@@ -7308,6 +7362,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/intl-messageformat": {
       "version": "9.11.4",
       "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-9.11.4.tgz",
@@ -12915,11 +12978,11 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
-      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
       "requires": {
-        "@babel/highlight": "^7.16.7"
+        "@babel/highlight": "^7.18.6"
       }
     },
     "@babel/compat-data": {
@@ -13078,9 +13141,9 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g=="
     },
     "@babel/helper-validator-option": {
       "version": "7.16.7",
@@ -13098,11 +13161,11 @@
       }
     },
     "@babel/highlight": {
-      "version": "7.16.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
-      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -13136,17 +13199,17 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
         },
         "supports-color": {
           "version": "5.5.0",
@@ -13159,9 +13222,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.17.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.3.tgz",
-      "integrity": "sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA=="
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.6.tgz",
+      "integrity": "sha512-uQVSa9jJUe/G/304lXspfWVpKpK4euFLgGiMQFOCpM/bgcAdeoHwi/OQz23O9GK2osz26ZiXRRV9aV+Yl1O8tw=="
     },
     "@babel/plugin-syntax-jsx": {
       "version": "7.16.7",
@@ -13189,6 +13252,16 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "@babel/template": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.6.tgz",
+      "integrity": "sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==",
+      "requires": {
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.18.6",
+        "@babel/types": "^7.18.6"
+      }
+    },
     "@babel/traverse": {
       "version": "7.17.3",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
@@ -13214,11 +13287,11 @@
       }
     },
     "@babel/types": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
-      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.6.tgz",
+      "integrity": "sha512-NdBNzPDwed30fZdDQtVR7ZgaO4UKjuaQFH9VArS+HMnurlOY0JWN+4ROlu/iapMFwjRQU4pOG4StZfDmulEwGA==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -14052,6 +14125,42 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-5.2.0.tgz",
       "integrity": "sha512-OZhKy1w8/GF4GWtdiJc+o8sloWAHRueGB78FWFLZnueK7EHV9MzDVr4weJZMflJwMK4uuYLzcnJVnAoy3yB35g=="
+    },
+    "@reach/alert-dialog": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/alert-dialog/-/alert-dialog-0.17.0.tgz",
+      "integrity": "sha512-qJOp9JE2Jv8ALUhq5yJrrGITk1YCkkDFlqejI19qeAXsuQ/ZIKzeiDYSih+avb+1mfV4HEzB9WoVJWcRTOwjiQ==",
+      "requires": {
+        "@reach/auto-id": "0.17.0",
+        "@reach/dialog": "0.17.0",
+        "@reach/utils": "0.17.0",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.7.2",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
+    "@reach/auto-id": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.17.0.tgz",
+      "integrity": "sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==",
+      "requires": {
+        "@reach/utils": "0.17.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
     },
     "@reach/dialog": {
       "version": "0.17.0",
@@ -18652,6 +18761,12 @@
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       }
+    },
+    "interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true
     },
     "intl-messageformat": {
       "version": "9.11.4",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^1.0.6",
+    "@reach/alert-dialog": "^0.17.0",
     "@reach/dialog": "^0.17.0",
     "iron-session": "^6.0.5",
     "json-loader": "^0.5.7",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,6 +2,7 @@ import "../styles/globals.css";
 import "../styles/hydrogen.css";
 import "@reach/dialog/styles.css";
 import "../styles/dialog.css";
+import "../styles/alert-dialog.css";
 import French from "../lang/frCompiled.json";
 import type { AppProps } from "next/app";
 import { useRouter } from "next/router";

--- a/styles/alert-dialog.css
+++ b/styles/alert-dialog.css
@@ -1,0 +1,54 @@
+  [data-reach-alert-dialog-overlay] {
+    background-color: rgba(0, 0, 0, 0.85);
+    z-index: 9999;
+  }
+  
+  [data-reach-alert-dialog-content] {
+    padding: 1.5rem;
+    width: 95vw;
+  }
+  
+  [data-reach-alert-dialog-content].alert-dialog--centered {
+    margin: 0 auto !important;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+  
+  .alert-dialog__title {
+    padding-right: 2rem;
+    z-index: 1;
+  }
+  
+  .alert-dialog-close:hover {
+    opacity: 1;
+  }
+  
+  .alert-dialog__header {
+    margin: -1.5rem -1.5rem 1.5rem;
+  }
+  
+  .alert-dialog__content > :first-child,
+  .alert-dialog__footer > :first-child {
+    margin-top: 0;
+  }
+  
+  .alert-dialog__content > :last-child,
+  .alert-dialog__footer > :last-child {
+    margin-bottom: 0;
+  }
+  
+  /* Small */
+  @media (min-width: 48rem) {
+  }
+  
+  /* Medium */
+  @media (min-width: 64rem) {
+    [data-reach-alert-dialog-content] {
+      width: 60vw;
+    }  
+  }
+  
+  /* Large */
+  @media (min-width: 100rem) {
+  }
+  


### PR DESCRIPTION
- Adds `AlertDialog` component (based on reach [Alert Dialog](https://reach.tech/alert-dialog) component).
- Replaces `Dialog` component (based on reach [Dialog (Modal)](https://reach.tech/dialog) component) with `AlertDialog` in `SelectRoleDialog` component which reads out the _AlertDialogLabel_ (title) and _AlertDialogDescription_ (several paragraphs) when using a screen reader.

### Notes
Although the Alert Dialog component is the right one for the scenario, the lack of a dismiss button where the focus should begin on open on the [least destructive action](https://reach.tech/alert-dialog#alertdialog-leastdestructiveref) button (close) makes the `SelectRoleDialog` component less accessible and does not allow the user to escape from the screen. Adding a [least destructive action] button (ex. X icon) to close the screen in the top right-hand corner would achieve this as well as start the focus on an element that would appear before the buttons and therefore make it easier for a screen reader user to navigate to the title and description paragraphs rather than have to listen to it all being read out (for when using the Dialog (Modal)). If the **least destructive action** button cannot be an option, than an inferior and less accessible solution exists but would require some text to appear in the modal:

> The only time you shouldn't close the dialog on dismiss is when the dialog requires a choice and none of them are "cancel". For example, perhaps two records need to be merged and the user needs to pick the surviving record. Neither choice is less destructive than the other, in these cases you may want to alert the user they need to a make a choice on dismiss instead of closing the dialog.
- source: [reach docs](https://reach.tech/dialog/#:~:text=The%20only%20time,closing%20the%20dialog.)
